### PR TITLE
Use IO::Prompt::Tiny instead of reading <STDIN> directly

### DIFF
--- a/bin/metabase-profile
+++ b/bin/metabase-profile
@@ -12,6 +12,7 @@ use JSON 2;
 use Metabase::User::Profile;
 use Metabase::User::Secret;
 use Pod::Usage;
+use IO::Prompt::Tiny qw(prompt);
 
 my (%profile, $help, $output, $full_name, $email_address, $password);
 my $result = GetOptions(
@@ -43,12 +44,10 @@ my @prompts = (
   password      => 'password/secret',
 );
 
-$|++; # autoflush prompts
 while (@prompts) {
   my ($key, $phrase) = splice(@prompts,0,2);
   next if $profile{$key};
-  print "Enter $phrase\: ";
-  chomp( my $answer = <STDIN> );
+  chomp( my $answer = prompt("Enter $phrase\: ") );
   $profile{$key} = $answer;
 }
 


### PR DESCRIPTION
This is related to [RT#85428](https://rt.cpan.org/Ticket/Display.html?id=85428). This ticket actually applies to both CPAN::Reporter::Config and CPAN::Testers::Common::Client::Config (which is used by cpanm-reporter). Upon investigation, it turned out that IPC::Cmd would block when a script read from `STDIN`. I filed this as [RT #88315](https://rt.cpan.org/Ticket/Display.html?id=88315).
There is a quick fix for metabase-profile, though. If you use IO::Prompt::Tiny::prompt, then it works without blocking the parent script (I would love to know why).

This change won't affect running metabase-profile by itself, but will fix the operation of the two mentioned CPAN reporter configuration scripts on Windows.
